### PR TITLE
Fix multipart file fields in generated OpenAPI schema

### DIFF
--- a/src/backend/InvenTree/InvenTree/schema.py
+++ b/src/backend/InvenTree/InvenTree/schema.py
@@ -16,6 +16,7 @@ from drf_spectacular.utils import (
     extend_schema,
     extend_schema_view,
 )
+from rest_framework import serializers
 from rest_framework.pagination import LimitOffsetPagination
 
 from InvenTree.permissions import OASTokenMixin
@@ -45,6 +46,20 @@ class ExtendedOAuth2Scheme(DjangoOAuthToolkitScheme):
 
 class ExtendedAutoSchema(AutoSchema):
     """Extend drf-spectacular to allow customizing the schema to match the actual API behavior."""
+
+    def _map_serializer_field(self, field, direction, *args, **kwargs):
+        """Custom field mapping overrides, falling back to default behavior."""
+        schema = super()._map_serializer_field(field, direction, *args, **kwargs)
+
+        direction_value = getattr(direction, 'value', direction)
+
+        # File and image fields in request schemas must be represented as binary
+        # payloads. In response schemas they are still rendered as URLs.
+        if direction_value == 'request' and isinstance(field, serializers.FileField):
+            schema['type'] = 'string'
+            schema['format'] = 'binary'
+
+        return schema
 
     def is_bulk_action(self, ref: str) -> bool:
         """Check the class of the current view for the bulk mixins."""
@@ -242,81 +257,6 @@ def postprocess_required_nullable(result, generator, request, public):
                 required_fields.remove(field)
         if 'required' in schema and len(required_fields) == 0:
             schema.pop('required')
-
-    return result
-
-
-def postprocess_multipart_file_fields_binary(result, generator, request, public):
-    """Map multipart file fields from URI format to binary format.
-
-    drf-spectacular can emit ``type: string, format: uri`` for upload fields.
-    For multipart request payloads this should be represented as ``format: binary``
-    so generated clients treat these fields as file uploads.
-    """
-
-    components = result.get('components', {})
-    component_schemas = components.get('schemas', {})
-    component_request_bodies = components.get('requestBodies', {})
-
-    visited_objects = set()
-    visited_refs = set()
-
-    def _replace_uri_with_binary(schema):
-        if not isinstance(schema, dict):
-            return
-
-        obj_id = id(schema)
-        if obj_id in visited_objects:
-            return
-        visited_objects.add(obj_id)
-
-        if schema.get('type') == 'string' and schema.get('format') == 'uri':
-            schema['format'] = 'binary'
-
-        ref = schema.get('$ref')
-        if isinstance(ref, str) and ref.startswith('#/components/schemas/'):
-            ref_name = ref.split('/')[-1]
-            if ref_name not in visited_refs and ref_name in component_schemas:
-                visited_refs.add(ref_name)
-                _replace_uri_with_binary(component_schemas[ref_name])
-
-        for key in ['allOf', 'anyOf', 'oneOf']:
-            for item in schema.get(key, []):
-                _replace_uri_with_binary(item)
-
-        for prop_schema in schema.get('properties', {}).values():
-            _replace_uri_with_binary(prop_schema)
-
-        _replace_uri_with_binary(schema.get('items'))
-
-    def _process_request_body_content(content):
-        if not isinstance(content, dict):
-            return
-
-        for content_type, content_schema in content.items():
-            if not content_type.startswith('multipart/'):
-                continue
-
-            if not isinstance(content_schema, dict):
-                continue
-
-            _replace_uri_with_binary(content_schema.get('schema'))
-
-    for path_item in result.get('paths', {}).values():
-        if not isinstance(path_item, dict):
-            continue
-
-        for operation in path_item.values():
-            if not isinstance(operation, dict):
-                continue
-
-            request_body = operation.get('requestBody', {})
-
-            if '$ref' in request_body:
-                ref_name = request_body['$ref'].split('/')[-1]
-                request_body = component_request_bodies.get(ref_name, {})
-
-            _process_request_body_content(request_body.get('content', {}))
 
     return result
 

--- a/src/backend/InvenTree/InvenTree/schema.py
+++ b/src/backend/InvenTree/InvenTree/schema.py
@@ -246,6 +246,81 @@ def postprocess_required_nullable(result, generator, request, public):
     return result
 
 
+def postprocess_multipart_file_fields_binary(result, generator, request, public):
+    """Map multipart file fields from URI format to binary format.
+
+    drf-spectacular can emit ``type: string, format: uri`` for upload fields.
+    For multipart request payloads this should be represented as ``format: binary``
+    so generated clients treat these fields as file uploads.
+    """
+
+    components = result.get('components', {})
+    component_schemas = components.get('schemas', {})
+    component_request_bodies = components.get('requestBodies', {})
+
+    visited_objects = set()
+    visited_refs = set()
+
+    def _replace_uri_with_binary(schema):
+        if not isinstance(schema, dict):
+            return
+
+        obj_id = id(schema)
+        if obj_id in visited_objects:
+            return
+        visited_objects.add(obj_id)
+
+        if schema.get('type') == 'string' and schema.get('format') == 'uri':
+            schema['format'] = 'binary'
+
+        ref = schema.get('$ref')
+        if isinstance(ref, str) and ref.startswith('#/components/schemas/'):
+            ref_name = ref.split('/')[-1]
+            if ref_name not in visited_refs and ref_name in component_schemas:
+                visited_refs.add(ref_name)
+                _replace_uri_with_binary(component_schemas[ref_name])
+
+        for key in ['allOf', 'anyOf', 'oneOf']:
+            for item in schema.get(key, []):
+                _replace_uri_with_binary(item)
+
+        for prop_schema in schema.get('properties', {}).values():
+            _replace_uri_with_binary(prop_schema)
+
+        _replace_uri_with_binary(schema.get('items'))
+
+    def _process_request_body_content(content):
+        if not isinstance(content, dict):
+            return
+
+        for content_type, content_schema in content.items():
+            if not content_type.startswith('multipart/'):
+                continue
+
+            if not isinstance(content_schema, dict):
+                continue
+
+            _replace_uri_with_binary(content_schema.get('schema'))
+
+    for path_item in result.get('paths', {}).values():
+        if not isinstance(path_item, dict):
+            continue
+
+        for operation in path_item.values():
+            if not isinstance(operation, dict):
+                continue
+
+            request_body = operation.get('requestBody', {})
+
+            if '$ref' in request_body:
+                ref_name = request_body['$ref'].split('/')[-1]
+                request_body = component_request_bodies.get(ref_name, {})
+
+            _process_request_body_content(request_body.get('content', {}))
+
+    return result
+
+
 def postprocess_print_stats(result, generator, request, public):
     """Prints statistics against schema."""
     rlt_dict = {}

--- a/src/backend/InvenTree/InvenTree/setting/spectacular.py
+++ b/src/backend/InvenTree/InvenTree/setting/spectacular.py
@@ -22,7 +22,6 @@ def get_spectacular_settings():
         'POSTPROCESSING_HOOKS': [
             'InvenTree.schema.postprocess_schema_enums',
             'InvenTree.schema.postprocess_required_nullable',
-            'InvenTree.schema.postprocess_multipart_file_fields_binary',
             'InvenTree.schema.postprocess_print_stats',
         ],
         'ENUM_NAME_OVERRIDES': {

--- a/src/backend/InvenTree/InvenTree/setting/spectacular.py
+++ b/src/backend/InvenTree/InvenTree/setting/spectacular.py
@@ -22,6 +22,7 @@ def get_spectacular_settings():
         'POSTPROCESSING_HOOKS': [
             'InvenTree.schema.postprocess_schema_enums',
             'InvenTree.schema.postprocess_required_nullable',
+            'InvenTree.schema.postprocess_multipart_file_fields_binary',
             'InvenTree.schema.postprocess_print_stats',
         ],
         'ENUM_NAME_OVERRIDES': {

--- a/src/backend/InvenTree/InvenTree/tests.py
+++ b/src/backend/InvenTree/InvenTree/tests.py
@@ -1844,6 +1844,61 @@ class SchemaPostprocessingTest(TestCase):
         # required key removed when empty
         self.assertNotIn('required', schemas_out.get('SalesOrderShipment'))
 
+    def test_postprocess_multipart_file_fields_binary(self):
+        """Verify multipart upload fields are exposed as binary in the schema."""
+        result_in = self.create_result_structure()
+
+        result_in['components']['schemas']['UploadRequest'] = {
+            'properties': {
+                'image': {'type': 'string', 'format': 'uri', 'nullable': True},
+                'note': {'type': 'string'},
+            }
+        }
+
+        result_in['paths']['/api/test/upload/'] = {
+            'post': {
+                'requestBody': {
+                    'content': {
+                        'multipart/form-data': {
+                            'schema': {'$ref': '#/components/schemas/UploadRequest'}
+                        }
+                    }
+                }
+            }
+        }
+
+        # non-multipart payloads should not be modified
+        result_in['components']['schemas']['NonMultipartRequest'] = {
+            'properties': {
+                'website': {'type': 'string', 'format': 'uri', 'nullable': True},
+            }
+        }
+        result_in['paths']['/api/test/json/'] = {
+            'post': {
+                'requestBody': {
+                    'content': {
+                        'application/json': {
+                            'schema': {
+                                '$ref': '#/components/schemas/NonMultipartRequest'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        result_out = schema.postprocess_multipart_file_fields_binary(
+            result_in, {}, {}, {}
+        )
+        schemas_out = result_out['components']['schemas']
+
+        self.assertEqual(
+            schemas_out['UploadRequest']['properties']['image']['format'], 'binary'
+        )
+        self.assertEqual(
+            schemas_out['NonMultipartRequest']['properties']['website']['format'], 'uri'
+        )
+
 
 class URLCompatibilityTest(InvenTreeTestCase):
     """Unit test for legacy URL compatibility."""

--- a/src/backend/InvenTree/InvenTree/tests.py
+++ b/src/backend/InvenTree/InvenTree/tests.py
@@ -22,6 +22,7 @@ from djmoney.contrib.exchange.exceptions import MissingRate
 from djmoney.contrib.exchange.models import Rate, convert_money
 from djmoney.money import Money
 from maintenance_mode.core import get_maintenance_mode, set_maintenance_mode
+from rest_framework import serializers
 from sesame.utils import get_user
 from stdimage.models import StdImageFieldFile
 
@@ -1844,60 +1845,34 @@ class SchemaPostprocessingTest(TestCase):
         # required key removed when empty
         self.assertNotIn('required', schemas_out.get('SalesOrderShipment'))
 
-    def test_postprocess_multipart_file_fields_binary(self):
-        """Verify multipart upload fields are exposed as binary in the schema."""
-        result_in = self.create_result_structure()
+    def test_file_field_request_schema_binary(self):
+        """Verify only request file fields are exposed as binary."""
+        auto_schema = object.__new__(schema.ExtendedAutoSchema)
 
-        result_in['components']['schemas']['UploadRequest'] = {
-            'properties': {
-                'image': {'type': 'string', 'format': 'uri', 'nullable': True},
-                'note': {'type': 'string'},
-            }
-        }
+        mapped_schemas = [
+            {'type': 'string', 'format': 'uri', 'nullable': True},
+            {'type': 'string', 'format': 'uri'},
+            {'type': 'string', 'format': 'uri', 'nullable': True},
+        ]
 
-        result_in['paths']['/api/test/upload/'] = {
-            'post': {
-                'requestBody': {
-                    'content': {
-                        'multipart/form-data': {
-                            'schema': {'$ref': '#/components/schemas/UploadRequest'}
-                        }
-                    }
-                }
-            }
-        }
+        with mock.patch(
+            'drf_spectacular.openapi.AutoSchema._map_serializer_field',
+            side_effect=mapped_schemas,
+        ):
+            file_request = auto_schema._map_serializer_field(
+                serializers.FileField(allow_null=True), 'request'
+            )
+            url_request = auto_schema._map_serializer_field(
+                serializers.URLField(), 'request'
+            )
+            file_response = auto_schema._map_serializer_field(
+                serializers.FileField(allow_null=True), 'response'
+            )
 
-        # non-multipart payloads should not be modified
-        result_in['components']['schemas']['NonMultipartRequest'] = {
-            'properties': {
-                'website': {'type': 'string', 'format': 'uri', 'nullable': True},
-            }
-        }
-        result_in['paths']['/api/test/json/'] = {
-            'post': {
-                'requestBody': {
-                    'content': {
-                        'application/json': {
-                            'schema': {
-                                '$ref': '#/components/schemas/NonMultipartRequest'
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        result_out = schema.postprocess_multipart_file_fields_binary(
-            result_in, {}, {}, {}
-        )
-        schemas_out = result_out['components']['schemas']
-
-        self.assertEqual(
-            schemas_out['UploadRequest']['properties']['image']['format'], 'binary'
-        )
-        self.assertEqual(
-            schemas_out['NonMultipartRequest']['properties']['website']['format'], 'uri'
-        )
+        self.assertEqual(file_request['format'], 'binary')
+        self.assertTrue(file_request['nullable'])
+        self.assertEqual(url_request['format'], 'uri')
+        self.assertEqual(file_response['format'], 'uri')
 
 
 class URLCompatibilityTest(InvenTreeTestCase):


### PR DESCRIPTION
### Motivation
- The generated OpenAPI schema used `type: string, format: uri` for uploaded files which causes client generators to treat them as URLs instead of file uploads; multipart upload fields must be represented as `format: binary`.
- This change ensures all file-like fields included in `multipart/*` request bodies are exposed as binary so clients properly send files.

### Description
- Added a new postprocessing hook `postprocess_multipart_file_fields_binary` in `InvenTree.schema` that walks request body schemas and replaces `format: uri` with `format: binary` for schemas used under `multipart/*` content types.
- Added a unit test `test_postprocess_multipart_file_fields_binary` in `InvenTree.tests` which verifies multipart payloads are rewritten to `binary` while non-multipart (`application/json`) `uri` fields remain unchanged.
